### PR TITLE
SwiftLint as a step during the CI pipeline GitHub Action

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Linting
+      run: swift run swiftlint
     - name: Build
       run: swift build -v
     - name: Run tests
       run: swift test -v
-    - name: Linting
-      run: swift run swiftlint


### PR DESCRIPTION
This PR:

- Adds a SwiftLint step (leveraging the dependency in `Package.swift`) to lint during every CI job.

NOTES:

- This could be the first step of a more comprehensive SPM CI integration, see: https://www.lordcodes.com/articles/manage-automation-tasks-using-spm