### PR TITLE
Add tvOS and watchOS support to 'Package.swift'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "Pusher",
-    platforms: [.iOS("13.0"),
-                .macOS("10.15")],
+    platforms: [.iOS(.v13),
+                .macOS(.v10_15),
+                .tvOS(.v13),
+                .watchOS(.v6)],
     products: [
         .library(
             name: "Pusher",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Register for a [Pusher](https://pusher.com) account, set up a Channels app and u
 - iOS 13.0 and above
 - macOS 10.15 and above
 - tvOS 13.0 and above
+- watchOS 6.0 and above
 
 ## Installation
 


### PR DESCRIPTION
This PR:

- Adds explicit support for tvOS (13.0 and above) and watchOS (6.0 and above) to `Package.swift`
  - Also updates README
