### PR TITLE
Further fixes for Linux support

### DIFF
--- a/Sources/Pusher/Networking/Client/APIClient.swift
+++ b/Sources/Pusher/Networking/Client/APIClient.swift
@@ -1,5 +1,8 @@
 import APIota
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// A REST API client for the Pusher Channels HTTP API.
 struct APIClient: APIotaClient {

--- a/Sources/Pusher/Pusher.swift
+++ b/Sources/Pusher/Pusher.swift
@@ -1,5 +1,8 @@
 import APIota
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Manages operations when interacting with the Pusher Channels HTTP API.
 public class Pusher {

--- a/Sources/Pusher/Services/CryptoService.swift
+++ b/Sources/Pusher/Services/CryptoService.swift
@@ -15,26 +15,12 @@ struct CryptoService {
         /// An error occurred during a NaCl cryptographic operation.
         case naclError(_ error: Swift.Error)
 
-        /// Generation of random bytes failed with a `OSStatus` code.
-        case randomBytesGenerationError(statusCode: OSStatus)
-
-        /// Zero random bytes were requested.
-        case zeroRandomBytesRequested
-
         /// A localized human-readable description of the error.
         public var errorDescription: String? {
             switch self {
             case .naclError(error: let error):
                 return NSLocalizedString("A cryptographic operation failed with error: \(error.localizedDescription)",
                                          comment: "'.naclError' error text")
-
-            case .randomBytesGenerationError(statusCode: let code):
-                return NSLocalizedString("Generating random bytes failed with error: \(code).",
-                                         comment: "'.randomBytesGenerationError' error text")
-
-            case .zeroRandomBytesRequested:
-                return NSLocalizedString("Zero random bytes were requested.",
-                                         comment: "'.zeroRandomBytesRequested' error text")
             }
         }
     }

--- a/Sources/Pusher/Services/WebhookService.swift
+++ b/Sources/Pusher/Services/WebhookService.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Provides functionality for verifying the authenticity of received Webhook requests,
 /// and for decoding the request into a `Webhook` object.


### PR DESCRIPTION
This PR is a follow-up for #36 

- Adds missing `FoundationNetworking` statements where needed for compiling on Linux.
- Removes redundant `CryptoService.Error` cases