### PR TITLE
Bugfix: ordered json - request body vs body_md5

### DIFF
--- a/Sources/Pusher/Networking/Client/GetChannelEndpoint.swift
+++ b/Sources/Pusher/Networking/Client/GetChannelEndpoint.swift
@@ -8,7 +8,7 @@ struct GetChannelEndpoint: APIotaCodableEndpoint {
     typealias ErrorResponse = Data
     typealias Body = String
 
-    let encoder: JSONEncoder = JSONEncoder()
+    let encoder: JSONEncoder = JSONEncoder.iso8601Ordered
 
     let headers: HTTPHeaders? = APIClient.defaultHeaders
 

--- a/Sources/Pusher/Networking/Client/GetChannelsEndpoint.swift
+++ b/Sources/Pusher/Networking/Client/GetChannelsEndpoint.swift
@@ -8,7 +8,7 @@ struct GetChannelsEndpoint: APIotaCodableEndpoint {
     typealias ErrorResponse = Data
     typealias Body = String
 
-    let encoder: JSONEncoder = JSONEncoder()
+    let encoder: JSONEncoder = JSONEncoder.iso8601Ordered
 
     let headers: HTTPHeaders? = APIClient.defaultHeaders
 

--- a/Sources/Pusher/Networking/Client/GetUsersEndpoint.swift
+++ b/Sources/Pusher/Networking/Client/GetUsersEndpoint.swift
@@ -8,7 +8,7 @@ struct GetUsersEndpoint: APIotaCodableEndpoint {
     typealias ErrorResponse = Data
     typealias Body = String
 
-    let encoder: JSONEncoder = JSONEncoder()
+    let encoder: JSONEncoder = JSONEncoder.iso8601Ordered
 
     let headers: HTTPHeaders? = APIClient.defaultHeaders
 

--- a/Sources/Pusher/Networking/Client/TriggerBatchEventsEndpoint.swift
+++ b/Sources/Pusher/Networking/Client/TriggerBatchEventsEndpoint.swift
@@ -8,7 +8,7 @@ struct TriggerBatchEventsEndpoint: APIotaCodableEndpoint {
     typealias ErrorResponse = Data
     typealias Body = EventBatch
 
-    let encoder: JSONEncoder = JSONEncoder()
+    let encoder: JSONEncoder = JSONEncoder.iso8601Ordered
 
     var headers: HTTPHeaders? {
 

--- a/Sources/Pusher/Networking/Client/TriggerEventEndpoint.swift
+++ b/Sources/Pusher/Networking/Client/TriggerEventEndpoint.swift
@@ -8,7 +8,7 @@ struct TriggerEventEndpoint: APIotaCodableEndpoint {
     typealias ErrorResponse = Data
     typealias Body = Event
 
-    let encoder: JSONEncoder = JSONEncoder()
+    let encoder: JSONEncoder = JSONEncoder.iso8601Ordered
 
     var headers: HTTPHeaders? {
 

--- a/Sources/Pusher/Networking/Models/AuthInfo.swift
+++ b/Sources/Pusher/Networking/Models/AuthInfo.swift
@@ -47,7 +47,7 @@ struct AuthInfo: AuthInfoRecord {
                version: String = "1.0") where Body: Encodable {
 
         // Generate a MD5 digest of the body (if provided)
-        if let httpBody = httpBody, let bodyData = try? JSONEncoder().encode(httpBody) {
+        if let httpBody = httpBody, let bodyData = try? JSONEncoder.iso8601Ordered.encode(httpBody) {
             self.bodyMD5 = CryptoService.md5Digest(data: bodyData).hexEncodedString()
         } else {
             self.bodyMD5 = nil

--- a/Sources/Pusher/Networking/Models/JSONEncoder.swift
+++ b/Sources/Pusher/Networking/Models/JSONEncoder.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension JSONEncoder {
+    convenience init(dateEncodingStrategy: DateEncodingStrategy,
+                     outputFormatting: OutputFormatting = [],
+                     keyEncodingStrategy: KeyEncodingStrategy = .useDefaultKeys) {
+        self.init()
+        self.dateEncodingStrategy = dateEncodingStrategy
+        self.outputFormatting = outputFormatting
+        self.keyEncodingStrategy = keyEncodingStrategy
+    }
+}
+
+extension JSONEncoder {
+    static let shared = JSONEncoder()
+    static let iso8601 = JSONEncoder(dateEncodingStrategy: .iso8601)
+    static let iso8601Ordered = JSONEncoder(dateEncodingStrategy: .iso8601, outputFormatting: .sortedKeys)
+    static let iso8601PrettyPrinted = JSONEncoder(dateEncodingStrategy: .iso8601, outputFormatting: .prettyPrinted)
+}


### PR DESCRIPTION
The used JSONEncoder doesn't generate deterministically ordered JSON keys. We are encoding the same `httpBody` twice; once to compute md5 and another time during the request serialization. This results in the md5 being invalid because it is not generated from the actual body of the request.

This PR uses `outputFormattying: .sortedKeys` to fix the bug.