### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ self.pusher.trigger(events: [eventOne, eventTwo]]) { result in
 
 #### Excluding receipients
 
-In some situations, you want to stop the client that broadcasts an event from receiving it. You can do this (by specifying its `socketId`)[https://pusher.com/docs/channels/server_api/excluding-event-recipients] when triggering an event:
+In some situations, you want to stop the client that broadcasts an event from receiving it. You can do this [by specifying its `socketId`](https://pusher.com/docs/channels/server_api/excluding-event-recipients) when triggering an event:
 
 ```swift
 let socketIdToExclude = "123.456"


### PR DESCRIPTION
## What does this PR do?

I fixed a typo in README.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/26753/229778683-6cfb5da1-4f18-456a-935b-d84745ae91fb.png) | ![image](https://user-images.githubusercontent.com/26753/229778776-0d165cba-8081-4c84-b948-131d4b558256.png) |

## CHANGELOG

I didn't update the CHANGELOG because I didn't change the code.